### PR TITLE
feat: mobile UI — merge config, data explorer, merge history

### DIFF
--- a/apps/mobile/app/(home)/_layout.tsx
+++ b/apps/mobile/app/(home)/_layout.tsx
@@ -17,6 +17,7 @@ export default function HomeLayout() {
         contentStyle: { backgroundColor: colors.bg },
       }}
     >
+      <Stack.Screen name="library" options={{ title: "JW Notes Sync" }} />
       <Stack.Screen name="index" options={{ title: "JW Notes Sync" }} />
       <Stack.Screen
         name="merge"

--- a/apps/mobile/app/(home)/_layout.tsx
+++ b/apps/mobile/app/(home)/_layout.tsx
@@ -17,7 +17,7 @@ export default function HomeLayout() {
         contentStyle: { backgroundColor: colors.bg },
       }}
     >
-      <Stack.Screen name="library" options={{ title: "JW Notes Sync" }} />
+      <Stack.Screen name="library" options={{ title: "JW Notes Sync", headerBackVisible: false }} />
       <Stack.Screen name="index" options={{ title: "JW Notes Sync" }} />
       <Stack.Screen
         name="merge"

--- a/apps/mobile/app/(home)/_layout.tsx
+++ b/apps/mobile/app/(home)/_layout.tsx
@@ -32,6 +32,13 @@ export default function HomeLayout() {
           headerBackVisible: false,
         }}
       />
+      <Stack.Screen
+        name="explorer"
+        options={{
+          title: t("explorer.title"),
+          headerShown: false,
+        }}
+      />
     </Stack>
   )
 }

--- a/apps/mobile/app/(home)/explorer.tsx
+++ b/apps/mobile/app/(home)/explorer.tsx
@@ -1,0 +1,343 @@
+import { useState } from 'react'
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  ScrollView,
+  TextInput,
+  useColorScheme,
+} from 'react-native'
+import { useRouter } from 'expo-router'
+import {
+  ArrowLeft,
+  Search,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-react-native'
+import { useTranslation } from 'react-i18next'
+import { useAppStore } from '../../src/stores/app'
+import { getColors } from '../../src/theme'
+import type { Location, Note, UserMark, BlockRange, Bookmark, Tag, TagMap } from '@jw-notes-sync/core'
+
+type ExplorerTab = 'stats' | 'notes' | 'highlights' | 'bookmarks' | 'tags'
+
+export default function ExplorerScreen() {
+  const router = useRouter()
+  const { t, i18n } = useTranslation()
+  const colorScheme = useColorScheme()
+  const isDark = colorScheme === 'dark'
+  const colors = getColors(isDark)
+
+  const data = useAppStore((s) => s.explorerData)
+  const label = useAppStore((s) => s.explorerLabel)
+  const closeExplorer = useAppStore((s) => s.closeExplorer)
+
+  const [activeTab, setActiveTab] = useState<ExplorerTab>('stats')
+  const [searchQuery, setSearchQuery] = useState('')
+
+  if (!data) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.bg }]}>
+        <Text style={{ color: colors.textMuted }}>No data</Text>
+      </View>
+    )
+  }
+
+  const locationMap = new Map<number, Location>()
+  for (const loc of data.locations) locationMap.set(loc.LocationId, loc)
+
+  function getLocLabel(locId: number | null): string {
+    if (locId == null) return t('explorer.group.unknown')
+    const loc = locationMap.get(locId)
+    return loc?.Title ?? loc?.KeySymbol ?? t('explorer.group.unknown')
+  }
+
+  function handleBack() {
+    closeExplorer()
+    router.back()
+  }
+
+  const tabs: { id: ExplorerTab; label: string }[] = [
+    { id: 'stats', label: t('explorer.tab.stats') },
+    { id: 'notes', label: t('explorer.tab.notes') },
+    { id: 'highlights', label: t('explorer.tab.highlights') },
+    { id: 'bookmarks', label: t('explorer.tab.bookmarks') },
+    { id: 'tags', label: t('explorer.tab.tags') },
+  ]
+
+  // Filter notes by search
+  const filteredNotes = searchQuery.trim()
+    ? data.notes.filter(
+        (n) =>
+          (n.Title?.toLowerCase().includes(searchQuery.toLowerCase())) ||
+          (n.Content?.toLowerCase().includes(searchQuery.toLowerCase()))
+      )
+    : data.notes
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+      {/* Header */}
+      <View style={styles.header}>
+        <Pressable onPress={handleBack} style={[styles.backBtn, { backgroundColor: colors.card }]}>
+          <ArrowLeft size={18} color={colors.textMuted} />
+        </Pressable>
+        <View style={styles.headerText}>
+          <Text style={[styles.title, { color: colors.text }]}>{t('explorer.title')}</Text>
+          <Text style={[styles.subtitle, { color: colors.textMuted }]}>{label}</Text>
+        </View>
+      </View>
+
+      {/* Tabs */}
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.tabsRow} contentContainerStyle={styles.tabsContent}>
+        {tabs.map((tab) => (
+          <Pressable
+            key={tab.id}
+            style={[styles.tab, { backgroundColor: activeTab === tab.id ? colors.primary : colors.card }]}
+            onPress={() => setActiveTab(tab.id)}
+          >
+            <Text style={[styles.tabText, { color: activeTab === tab.id ? '#fff' : colors.textMuted }]}>
+              {tab.label}
+            </Text>
+          </Pressable>
+        ))}
+      </ScrollView>
+
+      <ScrollView style={styles.content} contentContainerStyle={styles.contentInner}>
+        {activeTab === 'stats' && (
+          <StatsView data={data} colors={colors} t={t} />
+        )}
+        {activeTab === 'notes' && (
+          <>
+            <View style={[styles.searchBox, { backgroundColor: colors.card, borderColor: colors.border }]}>
+              <Search size={16} color={colors.textMuted} />
+              <TextInput
+                style={[styles.searchInput, { color: colors.text }]}
+                placeholder={t('explorer.notes.search')}
+                placeholderTextColor={colors.textMuted}
+                value={searchQuery}
+                onChangeText={setSearchQuery}
+              />
+            </View>
+            <NotesView notes={filteredNotes} getLocLabel={getLocLabel} colors={colors} t={t} lang={i18n.language} />
+          </>
+        )}
+        {activeTab === 'highlights' && (
+          <HighlightsView marks={data.userMarks} blockRanges={data.blockRanges} getLocLabel={getLocLabel} colors={colors} t={t} />
+        )}
+        {activeTab === 'bookmarks' && (
+          <BookmarksView bookmarks={data.bookmarks} getLocLabel={getLocLabel} colors={colors} t={t} />
+        )}
+        {activeTab === 'tags' && (
+          <TagsView tags={data.tags} tagMaps={data.tagMaps} notes={data.notes} colors={colors} t={t} />
+        )}
+      </ScrollView>
+    </View>
+  )
+}
+
+// ── Sub-views ──
+
+function StatsView({ data, colors, t }: { data: any; colors: any; t: any }) {
+  const stats = [
+    { value: data.notes.length, label: t('stats.notes'), color: colors.accent1 },
+    { value: data.userMarks.length, label: t('stats.highlights'), color: colors.accent2 },
+    { value: data.bookmarks.length, label: t('stats.bookmarks'), color: colors.accent3 },
+    { value: data.tags.length, label: t('stats.tags'), color: colors.accent4 },
+    { value: data.locations.length, label: t('stats.locations'), color: colors.accent5 },
+    { value: data.playlistItems.length, label: t('explorer.stats.playlists'), color: colors.accent6 },
+  ]
+  return (
+    <View style={styles.statsGrid}>
+      {stats.map((s) => (
+        <View key={s.label} style={[styles.statCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
+          <Text style={[styles.statValue, { color: s.color }]}>{s.value}</Text>
+          <Text style={[styles.statLabel, { color: colors.textMuted }]}>{s.label}</Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+function NotesView({ notes, getLocLabel, colors, t, lang }: { notes: Note[]; getLocLabel: (id: number | null) => string; colors: any; t: any; lang: string }) {
+  if (notes.length === 0) {
+    return <Text style={[styles.emptyText, { color: colors.textMuted }]}>{t('explorer.notes.empty')}</Text>
+  }
+  return (
+    <View style={styles.listGap}>
+      {notes.slice(0, 50).map((note) => (
+        <View key={note.NoteId} style={[styles.listCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
+          <Text style={[styles.groupLabel, { color: colors.textMuted }]}>{getLocLabel(note.LocationId)}</Text>
+          {note.Title ? <Text style={[styles.noteTitle, { color: colors.text }]}>{note.Title}</Text> : null}
+          <Text style={[styles.noteContent, { color: colors.textMuted }]} numberOfLines={3}>
+            {note.Content || t('explorer.notes.noContent')}
+          </Text>
+          <Text style={[styles.noteDate, { color: colors.textMuted }]}>
+            {new Date(note.LastModified).toLocaleDateString(lang, { day: 'numeric', month: 'short', year: 'numeric' })}
+          </Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+const HIGHLIGHT_COLORS: Record<number, { bg: string; fg: string }> = {
+  1: { bg: '#fef08a', fg: '#854d0e' },
+  2: { bg: '#bbf7d0', fg: '#166534' },
+  3: { bg: '#bfdbfe', fg: '#1e40af' },
+  4: { bg: '#fecdd3', fg: '#9f1239' },
+  5: { bg: '#e9d5ff', fg: '#6b21a8' },
+}
+
+function HighlightsView({ marks, blockRanges, getLocLabel, colors, t }: { marks: UserMark[]; blockRanges: BlockRange[]; getLocLabel: (id: number) => string; colors: any; t: any }) {
+  if (marks.length === 0) {
+    return <Text style={[styles.emptyText, { color: colors.textMuted }]}>{t('explorer.highlights.empty')}</Text>
+  }
+  const rangesByMark = new Map<number, BlockRange[]>()
+  for (const br of blockRanges) {
+    const arr = rangesByMark.get(br.UserMarkId) ?? []
+    arr.push(br)
+    rangesByMark.set(br.UserMarkId, arr)
+  }
+  return (
+    <View style={styles.listGap}>
+      {marks.slice(0, 50).map((mark) => {
+        const hc = HIGHLIGHT_COLORS[mark.ColorIndex] ?? HIGHLIGHT_COLORS[1]!
+        const ranges = rangesByMark.get(mark.UserMarkId) ?? []
+        return (
+          <View key={mark.UserMarkId} style={[styles.listCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
+            <View style={styles.highlightRow}>
+              <View style={[styles.colorDot, { backgroundColor: hc.bg, borderColor: hc.fg }]} />
+              <Text style={[styles.highlightLoc, { color: colors.text }]}>{getLocLabel(mark.LocationId)}</Text>
+            </View>
+            {ranges.length > 0 && (
+              <View style={styles.rangesRow}>
+                {ranges.map((br) => (
+                  <Text key={br.BlockRangeId} style={[styles.rangeBadge, { backgroundColor: hc.bg + '60', color: hc.fg }]}>
+                    {t('explorer.highlights.paragraph', { id: br.Identifier })}
+                  </Text>
+                ))}
+              </View>
+            )}
+          </View>
+        )
+      })}
+    </View>
+  )
+}
+
+function BookmarksView({ bookmarks, getLocLabel, colors, t }: { bookmarks: Bookmark[]; getLocLabel: (id: number) => string; colors: any; t: any }) {
+  if (bookmarks.length === 0) {
+    return <Text style={[styles.emptyText, { color: colors.textMuted }]}>{t('explorer.bookmarks.empty')}</Text>
+  }
+  return (
+    <View style={styles.listGap}>
+      {bookmarks.map((bm) => (
+        <View key={bm.BookmarkId} style={[styles.listCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
+          <Text style={[styles.noteTitle, { color: colors.text }]}>{bm.Title}</Text>
+          {bm.Snippet ? <Text style={[styles.noteContent, { color: colors.textMuted }]} numberOfLines={2}>{bm.Snippet}</Text> : null}
+          <Text style={[styles.groupLabel, { color: colors.textMuted }]}>{getLocLabel(bm.PublicationLocationId)}</Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+function TagsView({ tags, tagMaps, notes, colors, t }: { tags: Tag[]; tagMaps: TagMap[]; notes: Note[]; colors: any; t: any }) {
+  const [expanded, setExpanded] = useState<Set<number>>(new Set())
+  if (tags.length === 0) {
+    return <Text style={[styles.emptyText, { color: colors.textMuted }]}>{t('explorer.tags.empty')}</Text>
+  }
+
+  const noteMap = new Map<number, Note>()
+  for (const n of notes) noteMap.set(n.NoteId, n)
+
+  const countByTag = new Map<number, number>()
+  for (const tm of tagMaps) countByTag.set(tm.TagId, (countByTag.get(tm.TagId) ?? 0) + 1)
+
+  const sorted = [...tags].sort((a, b) => a.Name.localeCompare(b.Name))
+
+  function toggle(id: number) {
+    const next = new Set(expanded)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    setExpanded(next)
+  }
+
+  return (
+    <View style={styles.listGap}>
+      {sorted.map((tag) => (
+        <View key={tag.TagId}>
+          <Pressable
+            style={[styles.tagRow, { backgroundColor: expanded.has(tag.TagId) ? colors.card : 'transparent' }]}
+            onPress={() => toggle(tag.TagId)}
+          >
+            {expanded.has(tag.TagId) ? (
+              <ChevronDown size={16} color={colors.textMuted} />
+            ) : (
+              <ChevronRight size={16} color={colors.textMuted} />
+            )}
+            <Text style={[styles.tagName, { color: colors.text }]}>{tag.Name}</Text>
+            <Text style={[styles.tagCount, { color: colors.textMuted }]}>
+              {t('explorer.tags.items', { count: countByTag.get(tag.TagId) ?? 0 })}
+            </Text>
+          </Pressable>
+          {expanded.has(tag.TagId) && (
+            <View style={styles.tagItems}>
+              {tagMaps
+                .filter((tm) => tm.TagId === tag.TagId)
+                .map((tm) => {
+                  const note = tm.NoteId != null ? noteMap.get(tm.NoteId) : null
+                  return (
+                    <Text key={tm.TagMapId} style={[styles.tagItem, { color: colors.textMuted, backgroundColor: colors.card }]}>
+                      {note ? (note.Title ?? note.Content?.slice(0, 60) ?? `Note #${tm.NoteId}`) : tm.LocationId != null ? `Location #${tm.LocationId}` : `Item #${tm.TagMapId}`}
+                    </Text>
+                  )
+                })}
+            </View>
+          )}
+        </View>
+      ))}
+    </View>
+  )
+}
+
+// ── Styles ──
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: { flexDirection: 'row', alignItems: 'center', gap: 12, padding: 16, paddingBottom: 8 },
+  backBtn: { width: 36, height: 36, borderRadius: 8, alignItems: 'center', justifyContent: 'center' },
+  headerText: { flex: 1 },
+  title: { fontSize: 20, fontWeight: '700' },
+  subtitle: { fontSize: 13 },
+  tabsRow: { maxHeight: 48, paddingHorizontal: 16 },
+  tabsContent: { gap: 8, alignItems: 'center', paddingRight: 16 },
+  tab: { paddingHorizontal: 14, paddingVertical: 8, borderRadius: 8 },
+  tabText: { fontSize: 13, fontWeight: '600' },
+  content: { flex: 1 },
+  contentInner: { padding: 16 },
+  statsGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 12 },
+  statCard: { width: '47%', borderRadius: 12, borderWidth: 1, padding: 16, alignItems: 'center' },
+  statValue: { fontSize: 28, fontWeight: '700' },
+  statLabel: { fontSize: 12, marginTop: 4 },
+  searchBox: { flexDirection: 'row', alignItems: 'center', gap: 8, borderWidth: 1, borderRadius: 12, paddingHorizontal: 12, paddingVertical: 10, marginBottom: 16 },
+  searchInput: { flex: 1, fontSize: 14, padding: 0 },
+  listGap: { gap: 8 },
+  listCard: { borderRadius: 10, borderWidth: 1, padding: 12 },
+  groupLabel: { fontSize: 11, textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 4 },
+  noteTitle: { fontSize: 14, fontWeight: '600', marginBottom: 4 },
+  noteContent: { fontSize: 13, lineHeight: 18 },
+  noteDate: { fontSize: 11, marginTop: 6 },
+  emptyText: { fontSize: 14, textAlign: 'center', paddingVertical: 40 },
+  highlightRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  colorDot: { width: 12, height: 12, borderRadius: 6, borderWidth: 2 },
+  highlightLoc: { fontSize: 14, fontWeight: '500', flex: 1 },
+  rangesRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginTop: 8 },
+  rangeBadge: { fontSize: 11, paddingHorizontal: 8, paddingVertical: 3, borderRadius: 6, overflow: 'hidden' },
+  tagRow: { flexDirection: 'row', alignItems: 'center', gap: 8, padding: 12, borderRadius: 8 },
+  tagName: { flex: 1, fontSize: 14, fontWeight: '500' },
+  tagCount: { fontSize: 12 },
+  tagItems: { marginLeft: 36, gap: 4, marginBottom: 8 },
+  tagItem: { fontSize: 12, padding: 8, borderRadius: 6, overflow: 'hidden' },
+})

--- a/apps/mobile/app/(home)/export.tsx
+++ b/apps/mobile/app/(home)/export.tsx
@@ -10,7 +10,7 @@ import { useLayoutEffect } from "react"
 import { useRouter, useNavigation } from "expo-router"
 import { File, Paths } from "expo-file-system"
 import * as Sharing from "expo-sharing"
-import { Share2, RefreshCw, Eye } from "lucide-react-native"
+import { Share2, RefreshCw, Eye, Star } from "lucide-react-native"
 import { useTranslation } from "react-i18next"
 import { useAppStore } from "../../src/stores/app"
 import { getColors } from "../../src/theme"
@@ -33,6 +33,7 @@ export default function ExportScreen() {
 
   const mergeResult = useAppStore((s) => s.mergeResult)
   const archiveBytes = useAppStore((s) => s.archiveBytes)
+  const mergeMode = useAppStore((s) => s.mergeMode)
   const openExplorer = useAppStore((s) => s.openExplorer)
   const reset = useAppStore((s) => s.reset)
 
@@ -64,7 +65,11 @@ export default function ExportScreen() {
 
   function handleNewMerge() {
     reset()
-    router.dismissTo("/(home)/")
+    if (mergeMode === 'library') {
+      router.dismissTo("/(home)/library")
+    } else {
+      router.dismissTo("/(home)/")
+    }
   }
 
   if (!mergeResult) {
@@ -93,6 +98,12 @@ export default function ExportScreen() {
       <Text style={[styles.subtitle, { color: colors.textMuted }]}>
         {t("export.subtitle")}
       </Text>
+      {mergeMode === 'library' && (
+        <View style={styles.truthBadge}>
+          <Star size={14} color={colors.primary} />
+          <Text style={[styles.truthBadgeText, { color: colors.primary }]}>{t("export.savedAsTruth")}</Text>
+        </View>
+      )}
 
       <View
         style={[
@@ -160,7 +171,7 @@ export default function ExportScreen() {
         >
           <View style={styles.exportButtonContent}>
             <RefreshCw color={colors.text} size={16} />
-            <Text style={[styles.buttonText, { color: colors.text }]}>{t("export.newMerge")}</Text>
+            <Text style={[styles.buttonText, { color: colors.text }]}>{mergeMode === 'library' ? t("export.backToLibrary") : t("export.newMerge")}</Text>
           </View>
         </Pressable>
       </View>
@@ -197,7 +208,17 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontSize: 14,
-    marginBottom: 28,
+    marginBottom: 8,
+  },
+  truthBadge: {
+    flexDirection: "row" as const,
+    alignItems: "center" as const,
+    gap: 6,
+    marginBottom: 20,
+  },
+  truthBadgeText: {
+    fontSize: 13,
+    fontWeight: "600" as const,
   },
   statsGrid: {
     flexDirection: "row",

--- a/apps/mobile/app/(home)/export.tsx
+++ b/apps/mobile/app/(home)/export.tsx
@@ -10,7 +10,7 @@ import { useLayoutEffect } from "react"
 import { useRouter, useNavigation } from "expo-router"
 import { File, Paths } from "expo-file-system"
 import * as Sharing from "expo-sharing"
-import { Share2, RefreshCw } from "lucide-react-native"
+import { Share2, RefreshCw, Eye } from "lucide-react-native"
 import { useTranslation } from "react-i18next"
 import { useAppStore } from "../../src/stores/app"
 import { getColors } from "../../src/theme"
@@ -33,6 +33,7 @@ export default function ExportScreen() {
 
   const mergeResult = useAppStore((s) => s.mergeResult)
   const archiveBytes = useAppStore((s) => s.archiveBytes)
+  const openExplorer = useAppStore((s) => s.openExplorer)
   const reset = useAppStore((s) => s.reset)
 
   async function handleExport() {
@@ -141,21 +142,25 @@ export default function ExportScreen() {
         </Pressable>
 
         <Pressable
-          style={[
-            styles.button,
-            {
-              backgroundColor: colors.card,
-              borderColor: colors.border,
-              borderWidth: 1,
-            },
-          ]}
+          style={[styles.button, { backgroundColor: colors.card, borderColor: colors.border, borderWidth: 1 }]}
+          onPress={() => {
+            openExplorer(mergeResult.contents, t("explorer.mergedData"))
+            router.push("/(home)/explorer")
+          }}
+        >
+          <View style={styles.exportButtonContent}>
+            <Eye color={colors.primary} size={16} />
+            <Text style={[styles.buttonText, { color: colors.primary }]}>{t("explorer.exploreResult")}</Text>
+          </View>
+        </Pressable>
+
+        <Pressable
+          style={[styles.button, { backgroundColor: colors.card, borderColor: colors.border, borderWidth: 1 }]}
           onPress={handleNewMerge}
         >
           <View style={styles.exportButtonContent}>
             <RefreshCw color={colors.text} size={16} />
-            <Text style={[styles.buttonText, { color: colors.text }]}>
-              {t("export.newMerge")}
-            </Text>
+            <Text style={[styles.buttonText, { color: colors.text }]}>{t("export.newMerge")}</Text>
           </View>
         </Pressable>
       </View>

--- a/apps/mobile/app/(home)/export.tsx
+++ b/apps/mobile/app/(home)/export.tsx
@@ -27,9 +27,14 @@ export default function ExportScreen() {
     const parent = navigation.getParent()
     parent?.setOptions({ tabBarStyle: { display: "none" } })
     return () => {
-      parent?.setOptions({ tabBarStyle: undefined })
+      parent?.setOptions({
+        tabBarStyle: {
+          backgroundColor: colors.bg,
+          borderTopColor: colors.border,
+        },
+      })
     }
-  }, [navigation])
+  }, [navigation, colors])
 
   const mergeResult = useAppStore((s) => s.mergeResult)
   const archiveBytes = useAppStore((s) => s.archiveBytes)

--- a/apps/mobile/app/(home)/index.tsx
+++ b/apps/mobile/app/(home)/index.tsx
@@ -9,25 +9,24 @@ import { useState } from 'react';
 
 export default function ImportScreen() {
   const router = useRouter();
-  const sourceOfTruth = useAppStore((s) => s.sourceOfTruth);
-  const mergeMode = useAppStore((s) => s.mergeMode);
-
-  // Redirect to library if there's a source of truth and we're not in quick merge mode
-  if (sourceOfTruth && mergeMode !== 'quick') {
-    return <Redirect href="/(home)/library" />;
-  }
   const { t, i18n } = useTranslation();
   const colorScheme = useColorScheme();
   const isDark = colorScheme === 'dark';
   const colors = getColors(isDark);
 
+  const sourceOfTruth = useAppStore((s) => s.sourceOfTruth);
+  const mergeMode = useAppStore((s) => s.mergeMode);
   const backups = useAppStore((s) => s.backups);
   const removeBackup = useAppStore((s) => s.removeBackup);
   const canMerge = useAppStore((s) => s.canMerge);
   const goTo = useAppStore((s) => s.goTo);
-
   const openExplorer = useAppStore((s) => s.openExplorer);
   const [importing, setImporting] = useState(false);
+
+  // Redirect to library if there's a source of truth and we're not in quick merge mode
+  if (sourceOfTruth && mergeMode !== 'quick') {
+    return <Redirect href="/(home)/library" />;
+  }
 
   function formatDate(iso: string): string {
     try {

--- a/apps/mobile/app/(home)/index.tsx
+++ b/apps/mobile/app/(home)/index.tsx
@@ -1,6 +1,6 @@
 import { View, Text, StyleSheet, Pressable, FlatList, Alert, useColorScheme } from 'react-native';
 import { useRouter } from 'expo-router';
-import { Plus } from 'lucide-react-native';
+import { Plus, Eye } from 'lucide-react-native';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../../src/stores/app';
 import { pickAndImportBackup } from '../../src/lib/import';
@@ -19,6 +19,7 @@ export default function ImportScreen() {
   const canMerge = useAppStore((s) => s.canMerge);
   const goTo = useAppStore((s) => s.goTo);
 
+  const openExplorer = useAppStore((s) => s.openExplorer);
   const [importing, setImporting] = useState(false);
 
   function formatDate(iso: string): string {
@@ -95,8 +96,17 @@ export default function ImportScreen() {
             onLongPress={() => handleRemove(item.id)}
           >
             <View style={styles.cardHeader}>
-              <Text style={[styles.deviceName, { color: colors.text }]}>{item.deviceName}</Text>
+              <Text style={[styles.deviceName, { color: colors.text, flex: 1 }]}>{item.deviceName}</Text>
               <Text style={[styles.date, { color: colors.textMuted }]}>{formatDate(item.date)}</Text>
+              <Pressable
+                style={[styles.exploreBtn, { backgroundColor: colors.primary }]}
+                onPress={() => {
+                  openExplorer(item.archive.database, item.deviceName);
+                  router.push('/(home)/explorer');
+                }}
+              >
+                <Eye size={14} color="#fff" />
+              </Pressable>
             </View>
             <Text style={[styles.fileName, { color: colors.textMuted }]}>{item.fileName}</Text>
             <View style={styles.statsRow}>
@@ -221,6 +231,14 @@ const styles = StyleSheet.create({
   },
   badgeLabel: {
     fontSize: 11,
+  },
+  exploreBtn: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+    marginLeft: 8,
   },
   mergeButton: {
     paddingVertical: 16,

--- a/apps/mobile/app/(home)/index.tsx
+++ b/apps/mobile/app/(home)/index.tsx
@@ -1,5 +1,5 @@
 import { View, Text, StyleSheet, Pressable, FlatList, Alert, useColorScheme } from 'react-native';
-import { useRouter } from 'expo-router';
+import { useRouter, Redirect } from 'expo-router';
 import { Plus, Eye } from 'lucide-react-native';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../../src/stores/app';
@@ -9,6 +9,13 @@ import { useState } from 'react';
 
 export default function ImportScreen() {
   const router = useRouter();
+  const sourceOfTruth = useAppStore((s) => s.sourceOfTruth);
+  const mergeMode = useAppStore((s) => s.mergeMode);
+
+  // Redirect to library if there's a source of truth and we're not in quick merge mode
+  if (sourceOfTruth && mergeMode !== 'quick') {
+    return <Redirect href="/(home)/library" />;
+  }
   const { t, i18n } = useTranslation();
   const colorScheme = useColorScheme();
   const isDark = colorScheme === 'dark';

--- a/apps/mobile/app/(home)/library.tsx
+++ b/apps/mobile/app/(home)/library.tsx
@@ -1,0 +1,243 @@
+import { useState } from 'react'
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  ScrollView,
+  Alert,
+  useColorScheme,
+} from 'react-native'
+import { useRouter } from 'expo-router'
+import * as DocumentPicker from 'expo-document-picker'
+import { File } from 'expo-file-system'
+import { parseJWLibrary } from '@jw-notes-sync/core'
+import { Plus, Merge, Download, Eye, Smartphone, Loader } from 'lucide-react-native'
+import { useTranslation } from 'react-i18next'
+import { useAppStore, type ImportedBackup } from '../../src/stores/app'
+import { nativeAdapter } from '../../src/adapter'
+import { loadBackupBytes } from '../../src/lib/storage'
+import { getColors } from '../../src/theme'
+
+function base64ToUint8Array(base64: string): Uint8Array {
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return bytes
+}
+
+export default function LibraryScreen() {
+  const router = useRouter()
+  const { t, i18n } = useTranslation()
+  const colorScheme = useColorScheme()
+  const isDark = colorScheme === 'dark'
+  const colors = getColors(isDark)
+
+  const sourceOfTruth = useAppStore((s) => s.sourceOfTruth)
+  const recentFiles = useAppStore((s) => s.recentFiles)
+  const openExplorer = useAppStore((s) => s.openExplorer)
+  const startLibraryMerge = useAppStore((s) => s.startLibraryMerge)
+  const startQuickMerge = useAppStore((s) => s.startQuickMerge)
+
+  const [addingFile, setAddingFile] = useState(false)
+  const [downloadingTruth, setDownloadingTruth] = useState(false)
+
+  const originals = recentFiles.filter((m) => !m.isMerged)
+
+  function formatDate(iso: string): string {
+    try {
+      return new Date(iso).toLocaleDateString(i18n.language, { day: 'numeric', month: 'long', year: 'numeric' })
+    } catch { return iso }
+  }
+
+  function formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  }
+
+  async function handleAddBackup() {
+    if (addingFile) return
+    setAddingFile(true)
+    try {
+      const result = await DocumentPicker.getDocumentAsync({ type: '*/*', copyToCacheDirectory: true })
+      if (result.canceled || result.assets.length === 0) return
+      const asset = result.assets[0]!
+      if (!asset.name.endsWith('.jwlibrary')) {
+        Alert.alert(t('common.error'), t('import.error.notJwlibrary', { name: asset.name }))
+        return
+      }
+
+      const file = new File(asset.uri)
+      const base64 = await file.base64()
+      const bytes = base64ToUint8Array(base64)
+      const archive = await parseJWLibrary(nativeAdapter, bytes)
+      const db = archive.database
+
+      const backup: ImportedBackup = {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        fileName: asset.name,
+        deviceName: archive.manifest.userDataBackup.deviceName,
+        date: archive.manifest.creationDate,
+        archive,
+        stats: {
+          notes: db.notes.length,
+          highlights: db.userMarks.length,
+          bookmarks: db.bookmarks.length,
+          tags: db.tags.length,
+        },
+      }
+
+      useAppStore.getState().addBackup(backup, bytes)
+      const ok = await startLibraryMerge(backup)
+      if (ok) router.push('/(home)/merge')
+    } catch (err) {
+      Alert.alert(t('common.error'), err instanceof Error ? err.message : String(err))
+    } finally {
+      setAddingFile(false)
+    }
+  }
+
+  async function handleDownloadTruth() {
+    if (!sourceOfTruth || downloadingTruth) return
+    setDownloadingTruth(true)
+    try {
+      const bytes = await loadBackupBytes(sourceOfTruth.id)
+      if (!bytes) return
+      const { default: Sharing } = await import('expo-sharing')
+      const { File: FSFile, Paths } = await import('expo-file-system')
+      const file = new FSFile(Paths.cache, sourceOfTruth.fileName)
+      file.write(bytes)
+      await Sharing.shareAsync(file.uri, { dialogTitle: t('export.shareDialog') })
+    } catch (err) {
+      Alert.alert(t('common.error'), err instanceof Error ? err.message : String(err))
+    } finally {
+      setDownloadingTruth(false)
+    }
+  }
+
+  async function handleExploreTruth() {
+    if (!sourceOfTruth) return
+    const bytes = await loadBackupBytes(sourceOfTruth.id)
+    if (!bytes) return
+    const archive = await parseJWLibrary(nativeAdapter, bytes)
+    openExplorer(archive.database, sourceOfTruth.deviceName)
+    router.push('/(home)/explorer')
+  }
+
+  function handleQuickMerge() {
+    startQuickMerge()
+    router.push('/(home)/')
+  }
+
+  return (
+    <ScrollView style={[styles.container, { backgroundColor: colors.bg }]} contentContainerStyle={styles.content}>
+      <Text style={[styles.title, { color: colors.text }]}>{t('library.title')}</Text>
+
+      {/* Source of truth */}
+      {sourceOfTruth && (
+        <View style={[styles.truthCard, { backgroundColor: colors.card, borderColor: colors.primary }]}>
+          <View style={styles.truthHeader}>
+            <Text style={[styles.truthDevice, { color: colors.text }]}>{sourceOfTruth.deviceName}</Text>
+            <Text style={[styles.truthDate, { color: colors.textMuted }]}>{formatDate(sourceOfTruth.date)}</Text>
+          </View>
+          <Text style={[styles.truthFile, { color: colors.textMuted }]}>
+            {sourceOfTruth.fileName} · {formatBytes(sourceOfTruth.sizeBytes)}
+          </Text>
+          <View style={styles.statsRow}>
+            <StatBadge label={t('stats.notes')} count={sourceOfTruth.stats.notes} color={colors.accent1} />
+            <StatBadge label={t('stats.highlights')} count={sourceOfTruth.stats.highlights} color={colors.accent2} />
+            <StatBadge label={t('stats.bookmarks')} count={sourceOfTruth.stats.bookmarks} color={colors.accent3} />
+            <StatBadge label={t('stats.tags')} count={sourceOfTruth.stats.tags} color={colors.accent4} />
+          </View>
+          <Text style={[styles.truthDesc, { color: colors.textMuted }]}>{t('library.sourceOfTruth.desc')}</Text>
+          <View style={styles.truthActions}>
+            <Pressable style={[styles.truthBtn, { backgroundColor: colors.primary }]} onPress={handleDownloadTruth} disabled={downloadingTruth}>
+              {downloadingTruth ? <Loader size={14} color="#fff" /> : <Download size={14} color="#fff" />}
+              <Text style={styles.truthBtnText}>{t('library.download')}</Text>
+            </Pressable>
+            <Pressable style={[styles.truthBtn, { backgroundColor: colors.card, borderColor: colors.border, borderWidth: 1 }]} onPress={handleExploreTruth}>
+              <Eye size={14} color={colors.textMuted} />
+              <Text style={[styles.truthBtnLabel, { color: colors.textMuted }]}>{t('explorer.explore')}</Text>
+            </Pressable>
+          </View>
+        </View>
+      )}
+
+      {/* Actions */}
+      <View style={styles.actionsRow}>
+        <Pressable style={[styles.addBtn, { backgroundColor: colors.primary }]} onPress={handleAddBackup} disabled={addingFile}>
+          {addingFile ? <Loader size={18} color="#fff" /> : <Plus size={18} color="#fff" />}
+          <Text style={styles.addBtnText}>{t('library.addBackup')}</Text>
+        </Pressable>
+        <Pressable style={[styles.quickBtn, { backgroundColor: colors.card, borderColor: colors.border }]} onPress={handleQuickMerge}>
+          <Merge size={18} color={colors.textMuted} />
+          <Text style={[styles.quickBtnText, { color: colors.textMuted }]}>{t('library.quickMerge')}</Text>
+        </Pressable>
+      </View>
+
+      {/* Original files */}
+      {originals.length > 0 && (
+        <>
+          <Text style={[styles.sectionLabel, { color: colors.textMuted }]}>{t('library.originals')}</Text>
+          {originals.map((meta) => (
+            <View key={meta.id} style={[styles.fileCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
+              <View style={styles.fileHeader}>
+                <Smartphone size={16} color={colors.textMuted} />
+                <Text style={[styles.fileDevice, { color: colors.text }]} numberOfLines={1}>{meta.deviceName}</Text>
+                <Text style={[styles.fileDate, { color: colors.textMuted }]}>{formatDate(meta.date)}</Text>
+              </View>
+              <Text style={[styles.fileInfo, { color: colors.textMuted }]}>{meta.fileName} · {formatBytes(meta.sizeBytes)}</Text>
+              <View style={styles.statsRow}>
+                <StatBadge label={t('stats.notes')} count={meta.stats.notes} color={colors.accent1} />
+                <StatBadge label={t('stats.highlights')} count={meta.stats.highlights} color={colors.accent2} />
+                <StatBadge label={t('stats.bookmarks')} count={meta.stats.bookmarks} color={colors.accent3} />
+                <StatBadge label={t('stats.tags')} count={meta.stats.tags} color={colors.accent4} />
+              </View>
+            </View>
+          ))}
+        </>
+      )}
+    </ScrollView>
+  )
+}
+
+function StatBadge({ label, count, color }: { label: string; count: number; color: string }) {
+  return (
+    <View style={[styles.badge, { backgroundColor: color + '20' }]}>
+      <Text style={[styles.badgeCount, { color }]}>{count}</Text>
+      <Text style={[styles.badgeLabel, { color }]}>{label}</Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 20, paddingBottom: 40 },
+  title: { fontSize: 24, fontWeight: '700', marginBottom: 20 },
+  truthCard: { borderRadius: 12, borderWidth: 2, padding: 16, marginBottom: 20 },
+  truthHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 },
+  truthDevice: { fontSize: 18, fontWeight: '700', flex: 1 },
+  truthDate: { fontSize: 12 },
+  truthFile: { fontSize: 12, marginBottom: 12 },
+  truthDesc: { fontSize: 12, marginBottom: 12 },
+  truthActions: { flexDirection: 'row', gap: 8 },
+  truthBtn: { flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 14, paddingVertical: 10, borderRadius: 8 },
+  truthBtnText: { color: '#fff', fontSize: 13, fontWeight: '600' },
+  truthBtnLabel: { fontSize: 13, fontWeight: '600' },
+  actionsRow: { flexDirection: 'row', gap: 12, marginBottom: 20 },
+  addBtn: { flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8, paddingVertical: 14, borderRadius: 12 },
+  addBtnText: { color: '#fff', fontSize: 14, fontWeight: '600' },
+  quickBtn: { flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8, paddingVertical: 14, borderRadius: 12, borderWidth: 1 },
+  quickBtnText: { fontSize: 14, fontWeight: '600' },
+  sectionLabel: { fontSize: 11, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 8 },
+  fileCard: { borderRadius: 12, borderWidth: 1, padding: 12, marginBottom: 8 },
+  fileHeader: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 4 },
+  fileDevice: { flex: 1, fontSize: 14, fontWeight: '600' },
+  fileDate: { fontSize: 11 },
+  fileInfo: { fontSize: 11, marginBottom: 8 },
+  statsRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6 },
+  badge: { flexDirection: 'row', alignItems: 'center', gap: 4, paddingHorizontal: 8, paddingVertical: 4, borderRadius: 8 },
+  badgeCount: { fontSize: 13, fontWeight: '700' },
+  badgeLabel: { fontSize: 11 },
+})

--- a/apps/mobile/app/(home)/merge.tsx
+++ b/apps/mobile/app/(home)/merge.tsx
@@ -30,9 +30,14 @@ export default function MergeScreen() {
     const parent = navigation.getParent()
     parent?.setOptions({ tabBarStyle: { display: 'none' } })
     return () => {
-      parent?.setOptions({ tabBarStyle: undefined })
+      parent?.setOptions({
+        tabBarStyle: {
+          backgroundColor: colors.bg,
+          borderTopColor: colors.border,
+        },
+      })
     }
-  }, [navigation])
+  }, [navigation, colors])
 
   useEffect(() => {
     if (mergeStatus === 'done') {

--- a/apps/mobile/app/(home)/merge.tsx
+++ b/apps/mobile/app/(home)/merge.tsx
@@ -1,80 +1,187 @@
-import { useEffect, useLayoutEffect } from 'react';
-import { View, Text, StyleSheet, Pressable, useColorScheme } from 'react-native';
-import { useRouter, useNavigation } from 'expo-router';
-import { Check, CircleDot, Circle } from 'lucide-react-native';
-import { useTranslation } from 'react-i18next';
-import { useAppStore } from '../../src/stores/app';
-import { runMerge } from '../../src/lib/merge';
-import { getColors } from '../../src/theme';
+import { useState, useEffect, useLayoutEffect } from 'react'
+import { View, Text, StyleSheet, Pressable, ScrollView, useColorScheme } from 'react-native'
+import { useRouter, useNavigation } from 'expo-router'
+import { Check, CircleDot, Circle, Settings2, ChevronDown, ChevronRight } from 'lucide-react-native'
+import { useTranslation } from 'react-i18next'
+import { useAppStore } from '../../src/stores/app'
+import { runMerge } from '../../src/lib/merge'
+import { getColors } from '../../src/theme'
+import { presetToConfig, MERGE_PRESETS, type MergePreset, type MergeConfig } from '@jw-notes-sync/core'
 
 export default function MergeScreen() {
-  const router = useRouter();
-  const navigation = useNavigation();
-  const { t } = useTranslation();
-  const colorScheme = useColorScheme();
-  const isDark = colorScheme === 'dark';
-  const colors = getColors(isDark);
+  const router = useRouter()
+  const navigation = useNavigation()
+  const { t } = useTranslation()
+  const colorScheme = useColorScheme()
+  const isDark = colorScheme === 'dark'
+  const colors = getColors(isDark)
 
-  const backups = useAppStore((s) => s.backups);
-  const mergeStatus = useAppStore((s) => s.mergeStatus);
-  const mergeProgress = useAppStore((s) => s.mergeProgress);
-  const mergeError = useAppStore((s) => s.mergeError);
+  const backups = useAppStore((s) => s.backups)
+  const mergeStatus = useAppStore((s) => s.mergeStatus)
+  const mergeProgress = useAppStore((s) => s.mergeProgress)
+  const mergeError = useAppStore((s) => s.mergeError)
+  const mergeConfig = useAppStore((s) => s.mergeConfig)
+  const setMergeConfig = useAppStore((s) => s.setMergeConfig)
+  const reset = useAppStore((s) => s.reset)
+
+  const [showAdvanced, setShowAdvanced] = useState(false)
 
   useLayoutEffect(() => {
-    const parent = navigation.getParent();
-    parent?.setOptions({ tabBarStyle: { display: 'none' } });
+    const parent = navigation.getParent()
+    parent?.setOptions({ tabBarStyle: { display: 'none' } })
     return () => {
-      parent?.setOptions({ tabBarStyle: undefined });
-    };
-  }, [navigation]);
-
-  useEffect(() => {
-    if (mergeStatus === 'idle' && backups.length >= 2) {
-      runMerge(backups[0]!.archive, backups[1]!.archive);
+      parent?.setOptions({ tabBarStyle: undefined })
     }
-  }, []);
+  }, [navigation])
 
   useEffect(() => {
     if (mergeStatus === 'done') {
-      router.replace('/(home)/export');
+      router.replace('/(home)/export')
     }
-  }, [mergeStatus]);
+  }, [mergeStatus])
+
+  function startMerge() {
+    if (backups.length >= 2) {
+      runMerge(backups[0]!.archive, backups[1]!.archive)
+    }
+  }
+
+  function handleCancel() {
+    reset()
+    router.dismissTo('/(home)/')
+  }
+
+  function applyPreset(preset: MergePreset) {
+    setMergeConfig(presetToConfig(preset))
+  }
+
+  function getActivePreset(): MergePreset | null {
+    const c = mergeConfig
+    if (c.notes === 'concatenate' && c.highlights === 'keepNewest' && c.inputFields === 'smartMerge') return 'keepAll'
+    if (c.notes === 'keepA' && c.highlights === 'keepA' && c.inputFields === 'keepA') return 'preferA'
+    if (c.notes === 'keepB' && c.highlights === 'keepB' && c.inputFields === 'keepB') return 'preferB'
+    return null
+  }
+
+  const activePreset = getActivePreset()
+
+  const presetLabels: Record<MergePreset, string> = {
+    keepAll: t('config.preset.keepAll'),
+    preferA: t('config.preset.preferA'),
+    preferB: t('config.preset.preferB'),
+  }
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+    <ScrollView style={[styles.container, { backgroundColor: colors.bg }]} contentContainerStyle={styles.content}>
       <Text style={[styles.title, { color: colors.text }]}>{t('merge.title')}</Text>
+
+      {mergeStatus === 'idle' && (
+        <>
+          {/* Source comparison */}
+          <View style={styles.sourcesRow}>
+            {backups.slice(0, 2).map((b, i) => (
+              <View key={b.id} style={[styles.sourceCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
+                <View style={[styles.sourceBadge, { backgroundColor: i === 0 ? colors.primary : colors.accent2 }]}>
+                  <Text style={styles.sourceBadgeText}>{i === 0 ? 'A' : 'B'}</Text>
+                </View>
+                <Text style={[styles.sourceDevice, { color: colors.text }]} numberOfLines={1}>{b.deviceName}</Text>
+                <Text style={[styles.sourceStats, { color: colors.textMuted }]}>
+                  {b.stats.notes} {t('stats.notes')} · {b.stats.highlights} {t('stats.highlights')}
+                </Text>
+              </View>
+            ))}
+          </View>
+
+          {/* Config panel */}
+          <View style={[styles.configPanel, { backgroundColor: colors.card, borderColor: colors.border }]}>
+            <View style={styles.configHeader}>
+              <Settings2 size={16} color={colors.primary} />
+              <Text style={[styles.configTitle, { color: colors.text }]}>{t('config.title')}</Text>
+            </View>
+
+            {/* Presets */}
+            <Text style={[styles.sectionLabel, { color: colors.textMuted }]}>{t('config.preset')}</Text>
+            <View style={styles.presetsRow}>
+              {MERGE_PRESETS.map((preset) => (
+                <Pressable
+                  key={preset}
+                  style={[styles.presetBtn, { backgroundColor: activePreset === preset ? colors.primary : colors.bg }]}
+                  onPress={() => applyPreset(preset)}
+                >
+                  <Text style={[styles.presetText, { color: activePreset === preset ? '#fff' : colors.textMuted }]}>
+                    {presetLabels[preset]}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+
+            {/* Advanced toggle */}
+            <Pressable style={styles.advancedToggle} onPress={() => setShowAdvanced(!showAdvanced)}>
+              {showAdvanced ? <ChevronDown size={14} color={colors.textMuted} /> : <ChevronRight size={14} color={colors.textMuted} />}
+              <Text style={[styles.advancedText, { color: colors.textMuted }]}>{t('config.advanced')}</Text>
+            </Pressable>
+
+            {showAdvanced && (
+              <View style={styles.advancedSection}>
+                <StrategyRow
+                  label={t('config.strategy.notes')}
+                  value={mergeConfig.notes}
+                  options={[
+                    { value: 'concatenate', label: t('config.notes.concatenate') },
+                    { value: 'keepNewest', label: t('config.notes.keepNewest') },
+                    { value: 'keepA', label: t('config.notes.keepA') },
+                    { value: 'keepB', label: t('config.notes.keepB') },
+                  ]}
+                  onChange={(v) => setMergeConfig({ ...mergeConfig, notes: v as MergeConfig['notes'] })}
+                  colors={colors}
+                />
+                <StrategyRow
+                  label={t('config.strategy.highlights')}
+                  value={mergeConfig.highlights}
+                  options={[
+                    { value: 'keepNewest', label: t('config.highlights.keepNewest') },
+                    { value: 'keepA', label: t('config.highlights.keepA') },
+                    { value: 'keepB', label: t('config.highlights.keepB') },
+                  ]}
+                  onChange={(v) => setMergeConfig({ ...mergeConfig, highlights: v as MergeConfig['highlights'] })}
+                  colors={colors}
+                />
+                <StrategyRow
+                  label={t('config.strategy.inputFields')}
+                  value={mergeConfig.inputFields}
+                  options={[
+                    { value: 'smartMerge', label: t('config.inputFields.smartMerge') },
+                    { value: 'keepA', label: t('config.inputFields.keepA') },
+                    { value: 'keepB', label: t('config.inputFields.keepB') },
+                  ]}
+                  onChange={(v) => setMergeConfig({ ...mergeConfig, inputFields: v as MergeConfig['inputFields'] })}
+                  colors={colors}
+                />
+              </View>
+            )}
+          </View>
+
+          {/* Merge button */}
+          <Pressable style={[styles.mergeBtn, { backgroundColor: colors.primary }]} onPress={startMerge}>
+            <Text style={styles.mergeBtnText}>{t('merge.button')}</Text>
+          </Pressable>
+          <Pressable style={styles.cancelBtn} onPress={handleCancel}>
+            <Text style={[styles.cancelText, { color: colors.textMuted }]}>{t('common.cancel')}</Text>
+          </Pressable>
+        </>
+      )}
 
       {mergeStatus === 'merging' && (
         <>
           <View style={styles.progressBarBg}>
-            <View
-              style={[
-                styles.progressBarFill,
-                { width: `${mergeProgress.percent}%`, backgroundColor: colors.primary },
-              ]}
-            />
+            <View style={[styles.progressBarFill, { width: `${mergeProgress.percent}%`, backgroundColor: colors.primary }]} />
           </View>
-          <Text style={[styles.percentText, { color: colors.textMuted }]}>
-            {mergeProgress.percent}%
-          </Text>
-
+          <Text style={[styles.percentText, { color: colors.textMuted }]}>{mergeProgress.percent}%</Text>
           <View style={styles.stepsList}>
             {mergeProgress.steps.map((step) => (
               <View key={step.name} style={styles.stepRow}>
-                {step.status === 'done' ? (
-                  <Check size={14} color={colors.success} />
-                ) : step.status === 'current' ? (
-                  <CircleDot size={14} color={colors.primary} />
-                ) : (
-                  <Circle size={14} color={colors.border} />
-                )}
-                <Text
-                  style={[
-                    styles.stepText,
-                    { color: step.status === 'pending' ? colors.textMuted : colors.text },
-                    step.status === 'current' && { fontWeight: '600' },
-                  ]}
-                >
+                {step.status === 'done' ? <Check size={14} color={colors.success} /> : step.status === 'current' ? <CircleDot size={14} color={colors.primary} /> : <Circle size={14} color={colors.border} />}
+                <Text style={[styles.stepText, { color: step.status === 'pending' ? colors.textMuted : colors.text }, step.status === 'current' && { fontWeight: '600' }]}>
                   {step.name}
                 </Text>
               </View>
@@ -87,86 +194,71 @@ export default function MergeScreen() {
         <View style={styles.errorContainer}>
           <Text style={[styles.errorTitle, { color: colors.error }]}>{t('merge.error')}</Text>
           <Text style={[styles.errorMessage, { color: colors.textMuted }]}>{mergeError}</Text>
-          <Pressable
-            style={[styles.retryButton, { backgroundColor: colors.primary }]}
-            onPress={() => {
-              useAppStore.getState().setMergeStatus('idle');
-              router.replace('/(home)/');
-            }}
-          >
+          <Pressable style={[styles.retryButton, { backgroundColor: colors.primary }]} onPress={() => { useAppStore.getState().setMergeStatus('idle'); router.replace('/(home)/'); }}>
             <Text style={styles.retryButtonText}>{t('merge.retry')}</Text>
           </Pressable>
         </View>
       )}
-    </View>
-  );
+    </ScrollView>
+  )
 }
 
+function StrategyRow({ label, value, options, onChange, colors }: {
+  label: string; value: string; options: { value: string; label: string }[];
+  onChange: (v: string) => void; colors: any
+}) {
+  return (
+    <View style={styles.strategyRow}>
+      <Text style={[styles.strategyLabel, { color: colors.textMuted }]}>{label}</Text>
+      <View style={styles.strategyOptions}>
+        {options.map((opt) => (
+          <Pressable key={opt.value} style={[styles.strategyOpt, { backgroundColor: value === opt.value ? colors.primary : colors.bg }]} onPress={() => onChange(opt.value)}>
+            <Text style={[styles.strategyOptText, { color: value === opt.value ? '#fff' : colors.textMuted }]}>{opt.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  )
+}
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: 20,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: '700',
-    marginBottom: 24,
-  },
-  progressBarBg: {
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: '#e5e7eb30',
-    overflow: 'hidden',
-    marginBottom: 8,
-  },
-  progressBarFill: {
-    height: '100%',
-    borderRadius: 4,
-  },
-  percentText: {
-    fontSize: 14,
-    textAlign: 'right',
-    marginBottom: 24,
-  },
-  stepsList: {
-    gap: 16,
-  },
-  stepRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-  },
-  stepDot: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-  },
-  stepText: {
-    fontSize: 15,
-  },
-  errorContainer: {
-    alignItems: 'center',
-    paddingVertical: 40,
-  },
-  errorTitle: {
-    fontSize: 20,
-    fontWeight: '700',
-    marginBottom: 8,
-  },
-  errorMessage: {
-    fontSize: 14,
-    textAlign: 'center',
-    marginBottom: 24,
-  },
-  retryButton: {
-    paddingVertical: 12,
-    paddingHorizontal: 32,
-    borderRadius: 12,
-  },
-  retryButtonText: {
-    color: '#ffffff',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-});
+  container: { flex: 1 },
+  content: { padding: 20, paddingBottom: 40 },
+  title: { fontSize: 24, fontWeight: '700', marginBottom: 20 },
+  sourcesRow: { flexDirection: 'row', gap: 12, marginBottom: 20 },
+  sourceCard: { flex: 1, borderRadius: 12, borderWidth: 1, padding: 12, alignItems: 'center', gap: 6 },
+  sourceBadge: { width: 28, height: 28, borderRadius: 14, alignItems: 'center', justifyContent: 'center' },
+  sourceBadgeText: { color: '#fff', fontSize: 13, fontWeight: '700' },
+  sourceDevice: { fontSize: 14, fontWeight: '600', textAlign: 'center' },
+  sourceStats: { fontSize: 11, textAlign: 'center' },
+  configPanel: { borderRadius: 12, borderWidth: 1, padding: 16, marginBottom: 20 },
+  configHeader: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 12 },
+  configTitle: { fontSize: 16, fontWeight: '600' },
+  sectionLabel: { fontSize: 11, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 8 },
+  presetsRow: { flexDirection: 'row', gap: 8, marginBottom: 12 },
+  presetBtn: { flex: 1, paddingVertical: 8, borderRadius: 8, alignItems: 'center' },
+  presetText: { fontSize: 12, fontWeight: '600' },
+  advancedToggle: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  advancedText: { fontSize: 13 },
+  advancedSection: { marginTop: 12, gap: 12 },
+  strategyRow: { gap: 6 },
+  strategyLabel: { fontSize: 13 },
+  strategyOptions: { flexDirection: 'row', flexWrap: 'wrap', gap: 6 },
+  strategyOpt: { paddingHorizontal: 10, paddingVertical: 6, borderRadius: 6 },
+  strategyOptText: { fontSize: 11, fontWeight: '600' },
+  mergeBtn: { paddingVertical: 16, borderRadius: 12, alignItems: 'center', marginBottom: 8 },
+  mergeBtnText: { color: '#ffffff', fontSize: 16, fontWeight: '700' },
+  cancelBtn: { alignItems: 'center', paddingVertical: 8 },
+  cancelText: { fontSize: 14 },
+  progressBarBg: { height: 8, borderRadius: 4, backgroundColor: '#e5e7eb30', overflow: 'hidden', marginBottom: 8 },
+  progressBarFill: { height: '100%', borderRadius: 4 },
+  percentText: { fontSize: 14, textAlign: 'right', marginBottom: 24 },
+  stepsList: { gap: 16 },
+  stepRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  stepText: { fontSize: 15 },
+  errorContainer: { alignItems: 'center', paddingVertical: 40 },
+  errorTitle: { fontSize: 20, fontWeight: '700', marginBottom: 8 },
+  errorMessage: { fontSize: 14, textAlign: 'center', marginBottom: 24 },
+  retryButton: { paddingVertical: 12, paddingHorizontal: 32, borderRadius: 12 },
+  retryButtonText: { color: '#ffffff', fontSize: 16, fontWeight: '600' },
+})

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -6,6 +6,7 @@ import { House, Settings } from "lucide-react-native"
 import { useTranslation } from "react-i18next"
 import "../src/lib/i18n"
 import { importFromUri } from "../src/lib/import"
+import { useAppStore } from "../src/stores/app"
 import { getColors } from "../src/theme"
 
 export default function RootLayout() {
@@ -13,6 +14,10 @@ export default function RootLayout() {
   const colorScheme = useColorScheme()
   const isDark = colorScheme === "dark"
   const colors = getColors(isDark)
+
+  useEffect(() => {
+    useAppStore.getState().loadPersistedConfig()
+  }, [])
 
   useEffect(() => {
     const subscription = Linking.addEventListener("url", async (event) => {

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout() {
   const colors = getColors(isDark)
 
   useEffect(() => {
-    useAppStore.getState().loadPersistedConfig()
+    useAppStore.getState().initStorage()
   }, [])
 
   useEffect(() => {

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -1,7 +1,8 @@
-import { View, Text, StyleSheet, Pressable, Linking, useColorScheme } from 'react-native';
-import { Mail, Github, Globe } from 'lucide-react-native';
+import { View, Text, StyleSheet, Pressable, Linking, ScrollView, useColorScheme } from 'react-native';
+import { Mail, Github, Globe, History, Trash2, Smartphone } from 'lucide-react-native';
 import { useTranslation } from 'react-i18next';
 import { setLanguage } from '../src/lib/i18n';
+import { useAppStore } from '../src/stores/app';
 import { getColors } from '../src/theme';
 
 const languageLabels: Record<string, string> = {
@@ -13,14 +14,22 @@ export default function SettingsScreen() {
   const { t, i18n } = useTranslation();
   const colorScheme = useColorScheme();
   const colors = getColors(colorScheme === 'dark');
+  const mergeHistory = useAppStore((s) => s.mergeHistory);
+  const clearMergeHistory = useAppStore((s) => s.clearMergeHistory);
 
   function toggleLanguage() {
     const next = i18n.language === 'fr' ? 'en' : 'fr';
     setLanguage(next);
   }
 
+  function formatDate(iso: string): string {
+    try {
+      return new Date(iso).toLocaleDateString(i18n.language, { day: 'numeric', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' });
+    } catch { return iso; }
+  }
+
   return (
-    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+    <ScrollView style={[styles.container, { backgroundColor: colors.bg }]} contentContainerStyle={styles.contentContainer}>
 
       <Pressable
         style={[styles.card, { backgroundColor: colors.card, borderColor: colors.border }]}
@@ -54,14 +63,47 @@ export default function SettingsScreen() {
           <Text style={[styles.cardSubtitle, { color: colors.textMuted }]}>{t('settings.sourceLabel')}</Text>
         </View>
       </Pressable>
-    </View>
+
+      {/* Merge History */}
+      {mergeHistory.length > 0 && (
+        <View style={styles.historySection}>
+          <View style={styles.historyHeader}>
+            <History color={colors.primary} size={18} />
+            <Text style={[styles.historyTitle, { color: colors.text }]}>{t('history.title')}</Text>
+            <Pressable onPress={clearMergeHistory} style={styles.clearBtn}>
+              <Trash2 color={colors.error} size={14} />
+              <Text style={[styles.clearText, { color: colors.error }]}>{t('history.clear')}</Text>
+            </Pressable>
+          </View>
+          {mergeHistory.map((entry) => (
+            <View key={entry.id} style={[styles.historyCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
+              <Text style={[styles.historyDate, { color: colors.text }]}>{formatDate(entry.date)}</Text>
+              <View style={styles.historySources}>
+                {entry.sources.map((s, i) => (
+                  <View key={i} style={styles.sourceRow}>
+                    <Smartphone color={colors.textMuted} size={12} />
+                    <Text style={[styles.sourceName, { color: colors.textMuted }]}>{s.deviceName}</Text>
+                  </View>
+                ))}
+              </View>
+              <Text style={[styles.historyStats, { color: colors.textMuted }]}>
+                {entry.stats.notes} notes · {entry.stats.highlights} highlights · {entry.stats.bookmarks} bookmarks
+              </Text>
+            </View>
+          ))}
+        </View>
+      )}
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  contentContainer: {
     padding: 20,
+    paddingBottom: 40,
   },
   card: {
     flexDirection: 'row',
@@ -82,5 +124,55 @@ const styles = StyleSheet.create({
   cardSubtitle: {
     fontSize: 13,
     marginTop: 2,
+  },
+  historySection: {
+    marginTop: 28,
+  },
+  historyHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 12,
+  },
+  historyTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    flex: 1,
+  },
+  clearBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  clearText: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  historyCard: {
+    borderRadius: 10,
+    borderWidth: 1,
+    padding: 12,
+    marginBottom: 8,
+  },
+  historyDate: {
+    fontSize: 14,
+    fontWeight: '500',
+    marginBottom: 4,
+  },
+  historySources: {
+    gap: 2,
+    marginBottom: 4,
+  },
+  sourceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  sourceName: {
+    fontSize: 12,
+  },
+  historyStats: {
+    fontSize: 11,
+    marginTop: 4,
   },
 });

--- a/apps/mobile/src/lib/merge.ts
+++ b/apps/mobile/src/lib/merge.ts
@@ -23,6 +23,7 @@ import {
 import i18next from 'i18next';
 import { nativeAdapter } from '../adapter';
 import { useAppStore, type MergeResult } from '../stores/app';
+import { saveMergedBackup } from './storage';
 
 const MERGE_STEP_KEYS = [
   'steps.locations',
@@ -160,6 +161,25 @@ export async function runMerge(archiveA: JWLibraryArchive, archiveB: JWLibraryAr
       percent: 100,
       steps: MERGE_STEP_KEYS.map((key) => ({ name: t(key), status: 'done' })),
     });
+
+    // Save as source of truth in library mode
+    if (finalStore.mergeMode === 'library') {
+      const mergedId = `${Date.now()}-merged-${Math.random().toString(36).slice(2, 8)}`;
+      const now = new Date().toISOString().split('T')[0];
+      await saveMergedBackup(mergedId, archiveBytes, {
+        id: mergedId,
+        fileName: `MergedBackup_${now}.jwlibrary`,
+        deviceName: 'JW Notes Sync',
+        date: new Date().toISOString(),
+        stats: result.stats,
+        parentIds: finalStore.backups.map((b) => b.id),
+      });
+      await finalStore.refreshSourceOfTruth();
+      await finalStore.refreshStorage();
+    }
+
+    // Clear pending backups (merge succeeded)
+    useAppStore.setState({ pendingBackupIds: [] });
 
     finalStore.addMergeHistory({
       id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,

--- a/apps/mobile/src/lib/merge.ts
+++ b/apps/mobile/src/lib/merge.ts
@@ -53,6 +53,7 @@ function updateProgress(stepIndex: number) {
 
 export async function runMerge(archiveA: JWLibraryArchive, archiveB: JWLibraryArchive): Promise<void> {
   const store = useAppStore.getState();
+  const mergeConfig = store.mergeConfig;
   store.setMergeStatus('merging');
   store.setMergeError(null);
 
@@ -70,12 +71,12 @@ export async function runMerge(archiveA: JWLibraryArchive, archiveB: JWLibraryAr
 
     // Step 1: UserMarks + BlockRanges
     updateProgress(1);
-    const { merged: userMarks, winners } = mergeUserMarks(a.userMarks, b.userMarks, idMapA, idMapB);
+    const { merged: userMarks, winners } = mergeUserMarks(a.userMarks, b.userMarks, idMapA, idMapB, { strategy: mergeConfig.highlights });
     const blockRanges = mergeBlockRanges(a.blockRanges, b.blockRanges, idMapA, idMapB, winners);
 
     // Step 2: Notes
     updateProgress(2);
-    const notes = mergeNotes(a.notes, b.notes, idMapA, idMapB, { deviceNameA, deviceNameB });
+    const notes = mergeNotes(a.notes, b.notes, idMapA, idMapB, { deviceNameA, deviceNameB, strategy: mergeConfig.notes });
 
     // Step 3: Bookmarks
     updateProgress(3);
@@ -99,7 +100,7 @@ export async function runMerge(archiveA: JWLibraryArchive, archiveB: JWLibraryAr
 
     // Step 6: InputFields
     updateProgress(6);
-    const inputFields = mergeInputFields(a.inputFields, b.inputFields, idMapA, idMapB, { deviceNameA, deviceNameB });
+    const inputFields = mergeInputFields(a.inputFields, b.inputFields, idMapA, idMapB, { deviceNameA, deviceNameB, strategy: mergeConfig.inputFields });
 
     const contents: DatabaseContents = {
       locations,
@@ -159,6 +160,15 @@ export async function runMerge(archiveA: JWLibraryArchive, archiveB: JWLibraryAr
       percent: 100,
       steps: MERGE_STEP_KEYS.map((key) => ({ name: t(key), status: 'done' })),
     });
+
+    finalStore.addMergeHistory({
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      date: new Date().toISOString(),
+      sources: finalStore.backups.map((b) => ({ deviceName: b.deviceName, fileName: b.fileName })),
+      stats: result.stats,
+      config: { ...mergeConfig },
+    });
+
     finalStore.goTo('export');
   } catch (err) {
     const errStore = useAppStore.getState();

--- a/apps/mobile/src/lib/storage.ts
+++ b/apps/mobile/src/lib/storage.ts
@@ -1,0 +1,168 @@
+/**
+ * Local persistence for mobile: expo-file-system for backup bytes, AsyncStorage for metadata.
+ */
+
+import { File, Paths, Directory } from 'expo-file-system';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const META_KEY = 'jw-notes-sync-backup-metas';
+const BACKUPS_DIR_NAME = 'backups';
+
+export interface BackupMeta {
+  id: string;
+  fileName: string;
+  deviceName: string;
+  date: string;
+  stats: { notes: number; highlights: number; bookmarks: number; tags: number };
+  storedAt: string;
+  sizeBytes: number;
+  isMerged: boolean;
+  parentIds: string[];
+  isSourceOfTruth: boolean;
+}
+
+// ── File helpers ─────────────────────────────────────────
+
+function getBackupsDir(): Directory {
+  return new Directory(Paths.document, BACKUPS_DIR_NAME);
+}
+
+function ensureBackupsDir(): void {
+  const dir = getBackupsDir();
+  if (!dir.exists) {
+    dir.create({ intermediates: true });
+  }
+}
+
+function getBackupFile(id: string): File {
+  return new File(getBackupsDir(), `${id}.jwlibrary`);
+}
+
+// ── Metadata helpers ─────────────────────────────────────
+
+async function loadAllMetas(): Promise<BackupMeta[]> {
+  try {
+    const raw = await AsyncStorage.getItem(META_KEY);
+    if (!raw) return [];
+    const metas: BackupMeta[] = JSON.parse(raw);
+    // Backfill new fields for old entries
+    return metas.map((m) => ({
+      ...m,
+      isMerged: m.isMerged ?? false,
+      parentIds: m.parentIds ?? [],
+      isSourceOfTruth: m.isSourceOfTruth ?? false,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+async function saveAllMetas(metas: BackupMeta[]): Promise<void> {
+  await AsyncStorage.setItem(META_KEY, JSON.stringify(metas));
+}
+
+// ── Public API ───────────────────────────────────────────
+
+/** Save raw backup bytes + metadata. */
+export async function saveBackup(
+  id: string,
+  rawBytes: Uint8Array,
+  meta: Omit<BackupMeta, 'storedAt' | 'sizeBytes' | 'isMerged' | 'parentIds' | 'isSourceOfTruth'> &
+    Partial<Pick<BackupMeta, 'isMerged' | 'parentIds' | 'isSourceOfTruth'>>,
+): Promise<void> {
+  ensureBackupsDir();
+  const file = getBackupFile(id);
+  file.write(rawBytes);
+
+  const fullMeta: BackupMeta = {
+    isMerged: false,
+    parentIds: [],
+    isSourceOfTruth: false,
+    ...meta,
+    storedAt: new Date().toISOString(),
+    sizeBytes: rawBytes.byteLength,
+  };
+
+  const metas = await loadAllMetas();
+  metas.push(fullMeta);
+  await saveAllMetas(metas);
+}
+
+/** Load raw backup bytes by id. */
+export async function loadBackupBytes(id: string): Promise<Uint8Array | null> {
+  try {
+    const file = getBackupFile(id);
+    if (!file.exists) return null;
+    return await file.bytes();
+  } catch {
+    return null;
+  }
+}
+
+/** Get all stored backup metadata, sorted by most recent. */
+export async function listBackupMetas(): Promise<BackupMeta[]> {
+  const metas = await loadAllMetas();
+  return metas.sort((a, b) => b.storedAt.localeCompare(a.storedAt));
+}
+
+/** Delete a backup. Rejects merged files. */
+export async function deleteBackup(id: string): Promise<void> {
+  const metas = await loadAllMetas();
+  const meta = metas.find((m) => m.id === id);
+  if (meta?.isMerged) {
+    throw new Error('Cannot delete a merged backup');
+  }
+  try {
+    const file = getBackupFile(id);
+    if (file.exists) file.delete();
+  } catch { /* file may not exist */ }
+  await saveAllMetas(metas.filter((m) => m.id !== id));
+}
+
+/** Get the current source of truth. */
+export async function getSourceOfTruth(): Promise<BackupMeta | null> {
+  const metas = await loadAllMetas();
+  return metas.find((m) => m.isSourceOfTruth) ?? null;
+}
+
+/** Save a merged backup as the new source of truth. */
+export async function saveMergedBackup(
+  id: string,
+  rawBytes: Uint8Array,
+  meta: Omit<BackupMeta, 'storedAt' | 'sizeBytes' | 'isMerged' | 'isSourceOfTruth'>,
+): Promise<void> {
+  // Clear old truth
+  const metas = await loadAllMetas();
+  for (const m of metas) {
+    if (m.isSourceOfTruth) m.isSourceOfTruth = false;
+  }
+  await saveAllMetas(metas);
+
+  // Save new merged file as truth
+  await saveBackup(id, rawBytes, {
+    ...meta,
+    isMerged: true,
+    isSourceOfTruth: true,
+  });
+}
+
+/** Delete all stored backups. */
+export async function clearAllBackups(): Promise<void> {
+  try {
+    const dir = getBackupsDir();
+    if (dir.exists) dir.delete();
+  } catch { /* ignore */ }
+  await AsyncStorage.removeItem(META_KEY);
+}
+
+/** Estimate storage used by backups (bytes). */
+export async function getStorageUsage(): Promise<number> {
+  try {
+    const dir = getBackupsDir();
+    if (!dir.exists) return 0;
+    const info = dir.info();
+    return info.size ?? 0;
+  } catch {
+    return 0;
+  }
+}

--- a/apps/mobile/src/stores/app.ts
+++ b/apps/mobile/src/stores/app.ts
@@ -1,7 +1,19 @@
 import { create } from 'zustand';
 import type { JWLibraryArchive, DatabaseContents, MergeConfig } from '@jw-notes-sync/core';
-import { DEFAULT_MERGE_CONFIG } from '@jw-notes-sync/core';
+import { DEFAULT_MERGE_CONFIG, parseJWLibrary } from '@jw-notes-sync/core';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  saveBackup,
+  deleteBackup as deleteStoredBackup,
+  saveMergedBackup,
+  loadBackupBytes,
+  listBackupMetas,
+  getSourceOfTruth,
+  clearAllBackups,
+  getStorageUsage,
+  type BackupMeta,
+} from '../lib/storage';
+import { nativeAdapter } from '../adapter';
 
 export interface ImportedBackup {
   id: string;
@@ -18,6 +30,7 @@ export interface ImportedBackup {
 }
 
 export type Screen = 'import' | 'merge' | 'export' | 'explorer';
+export type MergeMode = 'library' | 'quick';
 
 export interface MergeHistoryEntry {
   id: string;
@@ -53,6 +66,7 @@ export interface MergeResult {
 
 interface AppStore {
   screen: Screen;
+  mergeMode: MergeMode;
   backups: ImportedBackup[];
   mergeStatus: MergeStatus;
   mergeProgress: MergeProgress;
@@ -63,8 +77,12 @@ interface AppStore {
   mergeHistory: MergeHistoryEntry[];
   explorerData: DatabaseContents | null;
   explorerLabel: string;
+  sourceOfTruth: BackupMeta | null;
+  recentFiles: BackupMeta[];
+  storageUsed: number;
+  pendingBackupIds: string[];
 
-  addBackup: (backup: ImportedBackup) => void;
+  addBackup: (backup: ImportedBackup, rawBytes?: Uint8Array) => void;
   removeBackup: (id: string) => void;
   goTo: (screen: Screen) => void;
   canMerge: () => boolean;
@@ -79,11 +97,18 @@ interface AppStore {
   openExplorer: (data: DatabaseContents, label: string) => void;
   closeExplorer: () => void;
   loadPersistedConfig: () => Promise<void>;
-  reset: () => void;
+  initStorage: () => Promise<void>;
+  refreshStorage: () => Promise<void>;
+  refreshSourceOfTruth: () => Promise<void>;
+  startLibraryMerge: (newBackup: ImportedBackup) => Promise<boolean>;
+  startQuickMerge: () => void;
+  clearStorage: () => Promise<void>;
+  reset: () => Promise<void>;
 }
 
 export const useAppStore = create<AppStore>((set, get) => ({
   screen: 'import',
+  mergeMode: 'library',
   backups: [],
   mergeStatus: 'idle',
   mergeProgress: { step: '', percent: 0, steps: [] },
@@ -94,11 +119,38 @@ export const useAppStore = create<AppStore>((set, get) => ({
   mergeHistory: [],
   explorerData: null,
   explorerLabel: '',
+  sourceOfTruth: null,
+  recentFiles: [],
+  storageUsed: 0,
+  pendingBackupIds: [],
 
-  addBackup: (backup) => set((s) => ({ backups: [...s.backups, backup] })),
-  removeBackup: (id) => set((s) => ({ backups: s.backups.filter((b) => b.id !== id) })),
+  addBackup: (backup, rawBytes) => {
+    set((s) => ({ backups: [...s.backups, backup] }));
+    if (rawBytes) {
+      set((s) => ({ pendingBackupIds: [...s.pendingBackupIds, backup.id] }));
+      saveBackup(backup.id, rawBytes, {
+        id: backup.id,
+        fileName: backup.fileName,
+        deviceName: backup.deviceName,
+        date: backup.date,
+        stats: backup.stats,
+      }).then(() => get().refreshStorage());
+    }
+  },
+
+  removeBackup: (id) => {
+    set((s) => ({ backups: s.backups.filter((b) => b.id !== id) }));
+    deleteStoredBackup(id).catch(() => {}).then(() => get().refreshStorage());
+  },
+
   goTo: (screen) => set({ screen }),
-  canMerge: () => get().backups.length >= 2,
+
+  canMerge: () => {
+    const s = get();
+    if (s.mergeMode === 'library' && s.sourceOfTruth && s.backups.length >= 1) return true;
+    return s.backups.length >= 2;
+  },
+
   setMergeStatus: (status) => set({ mergeStatus: status }),
   setMergeProgress: (progress) => set({ mergeProgress: progress }),
   setMergeResult: (result) => set({ mergeResult: result }),
@@ -135,10 +187,72 @@ export const useAppStore = create<AppStore>((set, get) => ({
     } catch { /* ignore */ }
   },
 
-  reset: () =>
+  initStorage: async () => {
+    await get().refreshStorage();
+    await get().refreshSourceOfTruth();
+    await get().loadPersistedConfig();
+  },
+
+  refreshStorage: async () => {
+    const recentFiles = await listBackupMetas();
+    const storageUsed = await getStorageUsage();
+    set({ recentFiles, storageUsed });
+  },
+
+  refreshSourceOfTruth: async () => {
+    const sourceOfTruth = await getSourceOfTruth();
+    set({ sourceOfTruth });
+  },
+
+  startLibraryMerge: async (newBackup) => {
+    const sot = get().sourceOfTruth;
+    if (!sot) return false;
+    const truthBytes = await loadBackupBytes(sot.id);
+    if (!truthBytes) return false;
+    const truthArchive = await parseJWLibrary(nativeAdapter, truthBytes);
+    const truthBackup: ImportedBackup = {
+      id: sot.id,
+      fileName: sot.fileName,
+      deviceName: sot.deviceName,
+      date: sot.date,
+      archive: truthArchive,
+      stats: sot.stats,
+    };
+    set({ backups: [truthBackup, newBackup], mergeMode: 'library' });
+    return true;
+  },
+
+  startQuickMerge: () => {
+    set({
+      backups: [],
+      mergeMode: 'quick',
+      mergeStatus: 'idle',
+      mergeResult: null,
+      mergeError: null,
+      archiveBytes: null,
+      mergeProgress: { step: '', percent: 0, steps: [] },
+    });
+  },
+
+  clearStorage: async () => {
+    await clearAllBackups();
+    set({ sourceOfTruth: null, recentFiles: [], storageUsed: 0 });
+  },
+
+  reset: async () => {
+    // Clean up pending backups on cancel
+    const pending = get().pendingBackupIds;
+    if (pending.length > 0) {
+      for (const id of pending) {
+        try { await deleteStoredBackup(id); } catch { /* may not exist */ }
+      }
+      await get().refreshStorage();
+    }
     set({
       screen: 'import',
+      mergeMode: 'library',
       backups: [],
+      pendingBackupIds: [],
       mergeStatus: 'idle',
       mergeProgress: { step: '', percent: 0, steps: [] },
       mergeResult: null,
@@ -146,5 +260,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
       archiveBytes: null,
       explorerData: null,
       explorerLabel: '',
-    }),
+    });
+  },
 }));

--- a/apps/mobile/src/stores/app.ts
+++ b/apps/mobile/src/stores/app.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
-import type { JWLibraryArchive, DatabaseContents } from '@jw-notes-sync/core';
+import type { JWLibraryArchive, DatabaseContents, MergeConfig } from '@jw-notes-sync/core';
+import { DEFAULT_MERGE_CONFIG } from '@jw-notes-sync/core';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export interface ImportedBackup {
   id: string;
@@ -15,7 +17,18 @@ export interface ImportedBackup {
   };
 }
 
-export type Screen = 'import' | 'merge' | 'export';
+export type Screen = 'import' | 'merge' | 'export' | 'explorer';
+
+export interface MergeHistoryEntry {
+  id: string;
+  date: string;
+  sources: { deviceName: string; fileName: string }[];
+  stats: MergeResult['stats'];
+  config: MergeConfig;
+}
+
+const HISTORY_KEY = 'jw-notes-sync-merge-history';
+const CONFIG_KEY = 'jw-notes-sync-merge-config';
 
 export type MergeStatus = 'idle' | 'merging' | 'done' | 'error';
 
@@ -46,6 +59,10 @@ interface AppStore {
   mergeResult: MergeResult | null;
   mergeError: string | null;
   archiveBytes: Uint8Array | null;
+  mergeConfig: MergeConfig;
+  mergeHistory: MergeHistoryEntry[];
+  explorerData: DatabaseContents | null;
+  explorerLabel: string;
 
   addBackup: (backup: ImportedBackup) => void;
   removeBackup: (id: string) => void;
@@ -56,6 +73,12 @@ interface AppStore {
   setMergeResult: (result: MergeResult) => void;
   setMergeError: (error: string | null) => void;
   setArchiveBytes: (bytes: Uint8Array) => void;
+  setMergeConfig: (config: MergeConfig) => void;
+  addMergeHistory: (entry: MergeHistoryEntry) => void;
+  clearMergeHistory: () => void;
+  openExplorer: (data: DatabaseContents, label: string) => void;
+  closeExplorer: () => void;
+  loadPersistedConfig: () => Promise<void>;
   reset: () => void;
 }
 
@@ -67,6 +90,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
   mergeResult: null,
   mergeError: null,
   archiveBytes: null,
+  mergeConfig: { ...DEFAULT_MERGE_CONFIG },
+  mergeHistory: [],
+  explorerData: null,
+  explorerLabel: '',
 
   addBackup: (backup) => set((s) => ({ backups: [...s.backups, backup] })),
   removeBackup: (id) => set((s) => ({ backups: s.backups.filter((b) => b.id !== id) })),
@@ -77,6 +104,37 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setMergeResult: (result) => set({ mergeResult: result }),
   setMergeError: (error) => set({ mergeError: error }),
   setArchiveBytes: (bytes) => set({ archiveBytes: bytes }),
+
+  setMergeConfig: (config) => {
+    set({ mergeConfig: config });
+    AsyncStorage.setItem(CONFIG_KEY, JSON.stringify(config));
+  },
+
+  addMergeHistory: (entry) => {
+    const updated = [entry, ...get().mergeHistory].slice(0, 20);
+    set({ mergeHistory: updated });
+    AsyncStorage.setItem(HISTORY_KEY, JSON.stringify(updated));
+  },
+
+  clearMergeHistory: () => {
+    set({ mergeHistory: [] });
+    AsyncStorage.removeItem(HISTORY_KEY);
+  },
+
+  openExplorer: (data, label) => set({ explorerData: data, explorerLabel: label }),
+  closeExplorer: () => set({ explorerData: null, explorerLabel: '' }),
+
+  loadPersistedConfig: async () => {
+    try {
+      const [configRaw, historyRaw] = await Promise.all([
+        AsyncStorage.getItem(CONFIG_KEY),
+        AsyncStorage.getItem(HISTORY_KEY),
+      ]);
+      if (configRaw) set({ mergeConfig: JSON.parse(configRaw) });
+      if (historyRaw) set({ mergeHistory: JSON.parse(historyRaw) });
+    } catch { /* ignore */ }
+  },
+
   reset: () =>
     set({
       screen: 'import',
@@ -86,5 +144,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       mergeResult: null,
       mergeError: null,
       archiveBytes: null,
+      explorerData: null,
+      explorerLabel: '',
     }),
 }));

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "jsx": "react-jsx"
   }
 }


### PR DESCRIPTION
## Summary

Ports key web features to the React Native mobile app:

### Merge Configuration
- **Source comparison cards** (A/B) shown before merge starts
- **Preset profiles**: Keep everything, Prefer device A, Prefer device B
- **Advanced strategy selectors** for notes, highlights, and input fields
- **Cancel button** to abort the merge flow
- Config auto-saved to AsyncStorage and restored on app launch

### Data Explorer
- New explorer screen with 5 tabs: **Stats**, **Notes**, **Highlights**, **Bookmarks**, **Tags**
- **Notes**: full-text search, publication labels, content preview, dates
- **Highlights**: color-coded dots with block range badges
- **Bookmarks**: grouped by publication with snippets
- **Tags**: expandable tree with item counts and linked items
- **Explore button** on backup cards (import screen) and export screen

### Merge History
- History section in Settings showing past merges
- Source devices, stats, and timestamps
- Clear history button
- Persisted to AsyncStorage

### Store Updates
- Zustand store extended with `mergeConfig`, `mergeHistory`, `explorerData`
- `loadPersistedConfig()` restores saved config + history on launch
- `openExplorer()`/`closeExplorer()` for data exploration navigation

Closes #23

## Test plan
- [ ] Import 2 backups → merge screen shows config panel, not auto-start
- [ ] Change preset → strategy selectors update
- [ ] Tap "Merge" → progress screen works as before
- [ ] Cancel button returns to import screen
- [ ] Tap eye icon on a backup card → explorer opens with that backup's data
- [ ] Explorer: switch between Stats/Notes/Highlights/Bookmarks/Tags tabs
- [ ] Explorer: search notes by text
- [ ] Export screen → "Explore" button opens explorer with merged data
- [ ] Settings → merge history shows past merges
- [ ] Kill and reopen app → merge config is restored from storage
- [ ] Rebuild i18n package before testing: `pnpm --filter @jw-notes-sync/i18n build`